### PR TITLE
Don't proactively fail when encountering ARG

### DIFF
--- a/pkg/dazzle/build.go
+++ b/pkg/dazzle/build.go
@@ -527,7 +527,7 @@ func (df *ParsedDockerfile) Validate() error {
 			}
 		}
 		if tkn.Value == command.Arg {
-			return fmt.Errorf("dazzle does not support build args")
+			log.Warn("dazzle does not support build ARGs (will act like unconfigurable ENV)")
 		}
 	}
 	return nil


### PR DESCRIPTION
Use case: I'd like to build a Dockerfile with Dazzle (`gitpod/workspace-full`). This Dockerfile will contain an `ARG`, but I'm okay with not being able to set a non-default value (i.e. it's fine if the `ARG` just acts like an unconfigured `ENV`, which Dazzle supports).

Expected behavior: Dazzle successfully builds the Dockerfile (without ability to set a non-default `ARG` value)

Actual behavior: Dazzle sees an `ARG` and decides to fail early