### PR TITLE
[build] Add project metadata to base and chunk manifests

### DIFF
--- a/pkg/dazzle/build.go
+++ b/pkg/dazzle/build.go
@@ -140,6 +140,19 @@ func (p *Project) Build(ctx context.Context, session *BuildSession) error {
 	if err != nil {
 		return fmt.Errorf("cannot fetch base image: %w", err)
 	}
+	if len(p.Config.Combiner.EnvVars) > 0 {
+		basemf.Annotations = make(map[string]string)
+		for _, e := range p.Config.Combiner.EnvVars {
+			basemf.Annotations["dazzle.gitpod.io/env-"+e.Name] = string(e.Action)
+		}
+
+		err = storeInRegistry(ctx, session.opts.Resolver, baseref, storeInRegistryOptions{
+			Manifest: basemf,
+		})
+		if err != nil {
+			return fmt.Errorf("cannot modify base manifest: %w", err)
+		}
+	}
 	session.baseBuildFinished(absbaseref, basemf, basecfg)
 
 	for _, chk := range p.Chunks {


### PR DESCRIPTION
This PR adds project metadata to the base and chunk manifests. Specifically it adds:
- `dazzle.gitpod.io/env-${name}: ${action}` annotations to the base image manifest for each configured environment variable to maintain the env var merge behaviour in absence of a `dazzle.yaml`
- `dazzle.gitpod.io/base-ref` annotation to the chunk image manifests to discover the base image they were built from and to verify multiple chunks were built from the base.

In absence of good tools for inspecting manifests, I've found it easiest to exec in to the registry container and inspect `/var/lib/registry/docker/registry/v2/` (look for the manifest first, then the blob referred to by the manifest content hash).