### PR TITLE
[build] Only add env var annotations for no-hash builds

### DIFF
--- a/pkg/dazzle/build_test.go
+++ b/pkg/dazzle/build_test.go
@@ -180,8 +180,8 @@ type testRegistry struct {
 	testResult *StoredTestResult
 }
 
-func (t testRegistry) Store(ctx context.Context, ref reference.Named, opts storeInRegistryOptions) error {
-	return nil
+func (t testRegistry) Push(ctx context.Context, ref reference.Named, opts storeInRegistryOptions) (absref reference.Digested, err error) {
+	return nil, nil
 }
 
 func (t testRegistry) Pull(ctx context.Context, ref reference.Reference, cfg interface{}) (manifest *ociv1.Manifest, absref reference.Digested, err error) {


### PR DESCRIPTION
Otherwise the computed base image name does not match the actual base image name which makes the chunk combination fail.

For `chunked-without-hash` that's not a problem because they take their base image ref from their own annotations.