### PR TITLE
Add golangci

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,3 +1,5 @@
 FROM gitpod/workspace-full
 RUN curl -sfL https://install.goreleaser.com/github.com/goreleaser/goreleaser.sh | sudo BINDIR=/usr/local/bin sh
 RUN sudo su -c "cd /usr; curl -L https://github.com/moby/buildkit/releases/download/v0.8.3/buildkit-v0.8.3.linux-amd64.tar.gz | tar xvz"
+# NOTE: remove when workspace-full includes golangci
+RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sudo BINDIR=/usr/local/bin sh

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,42 @@
+linters:
+  enable:
+    - revive
+    - staticcheck
+
+# output configuration options
+output:
+  # colored-line-number|line-number|json|tab|checkstyle|code-climate|junit-xml|github-actions
+  # default is "colored-line-number"
+  format: colored-line-number
+
+  # print lines of code with issue, default is true
+  print-issued-lines: true
+
+  # print linter name in the end of issue text, default is true
+  print-linter-name: true
+
+  # make issues output unique by line, default is true
+  uniq-by-line: true
+
+  # add a prefix to the output file references; default is no prefix
+  path-prefix: ""
+
+  # sorts results by: filepath, line and column
+  sort-results: false
+
+# all available settings of specific linters
+linters-settings:
+  revive:
+    # minimal confidence for issues, default is 0.8
+    confidence: 0.6
+    ignoreGeneratedHeader: false
+    severity: "warning"
+    errorCode: 0
+    warningCode: 0
+    rules:
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#error-strings
+      - name: error-strings
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#error-naming
+      - name: error-naming
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#error-return
+      - name: error-return

--- a/pkg/dazzle/build.go
+++ b/pkg/dazzle/build.go
@@ -556,11 +556,11 @@ func (p *ProjectChunk) test(ctx context.Context, sess *BuildSession) (ok bool, e
 
 	resultRef, err := p.ImageName(imageTypeTestResult, sess)
 	if err != nil {
-		return
+		return false, err
 	}
 	r, err := pullTestResult(ctx, sess.opts.Registry, resultRef)
 	if err != nil && !errdefs.IsNotFound(err) {
-		return
+		return false, err
 	}
 	if r != nil && r.Passed {
 		// tests have run before and have passed


### PR DESCRIPTION
Fix issue reported by staticcheck

VSCode does not report that the linter specified in the config is not present i.e. fails silently.

Gitpod's dev image *has* golangci installed but workspace-full, on which this repo depends, does not. PR to fix that [here](https://github.com/gitpod-io/workspace-images/pull/419)