### PR TITLE
Add integration tests

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -62,6 +62,13 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - build-go
+    services:
+      # Local registry
+      registr:
+        # Docker Hub image
+        image: registry:2
+        ports:
+          - 5000:5000
     steps:
       - name: Create checkout directory
         run: mkdir -p ~/go/src/github.com/gitpod-io
@@ -81,7 +88,25 @@ jobs:
       - name: Download and vendor all required packages
         run: |
           go mod download
+      - name: Build the test runner
+        run: pushd pkg/test/runner; ./build.sh; popd
+      - name: Install the latest buildkit release
+        run: |
+          BUILDKIT_URL="$(curl -sL https://api.github.com/repos/moby/buildkit/releases \
+            | jq -r 'map(select(.name|startswith("v")))|sort_by(.name)[-1].assets[]|select(.name|endswith(".linux-amd64.tar.gz")).browser_download_url')"
+          curl -L "${BUILDKIT_URL}" | sudo tar -xz -C /usr/local
+      - name: Start buildkit daemon
+        run: |
+          sudo --non-interactive --shell <<END_SUDO
+            install -d -m 0750 -o root -g docker /run/buildkit
+            buildkitd &
+            while ! test -S /run/buildkit/buildkitd.sock; do sleep 0.1; done
+            chgrp docker /run/buildkit/buildkitd.sock
+          END_SUDO
       - name: Run all unit tests
+        env:
+          BUILDKIT_ADDR: unix:///run/buildkit/buildkitd.sock
+          TARGET_REF: 127.0.0.1:5000
         run: go test -v -coverprofile=coverage.out $(go list ./...)
       - name: Generate code coverage artifacts
         uses: actions/upload-artifact@v2

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -27,6 +27,21 @@
             "args": [
                 "eyJEZXNjIjoiaXQgc2hvdWxkIGhhdmUgR28gaW4gdmVyc2lvbiAxLjEzIiwiU2tpcCI6ZmFsc2UsIlVzZXIiOiIiLCJDb21tYW5kIjpbImdvIiwidmVyc2lvbiJdLCJFbnRyeXBvaW50IjpudWxsLCJFbnYiOm51bGwsIkFzc2VydGlvbnMiOlsic3Rkb3V0LmluZGV4T2YoXCJnbzEuMTFcIikgIT0gLTEiXX0="
             ]
+        },
+        {
+            "name": "Launch build integration test",
+            "type": "go",
+            "request": "launch",
+            "mode": "test",
+            "program": "${fileWorkspaceFolder}/pkg/dazzle/build_test.go",
+            "args": [
+                "-test.run",
+                "TestProjectChunk_test_integration"
+            ],
+            "env": {
+                "BUILDKIT_ADDR": "unix:///run/buildkit/buildkitd.sock",
+                "TARGET_REF": "127.0.0.1:5000",
+            }
         }
     ]
 }

--- a/README.md
+++ b/README.md
@@ -204,3 +204,15 @@ They can be extracted using jq e.g.:
 $ go run pkg/test/runner/main.go eyJEZXNjIjoiaXQgc2hvdWxkIGhhdmUgR28gaW4gdmVyc2lvbiAxLjEzIiwiU2tpcCI6ZmFsc2UsIlVzZXIiOiIiLCJDb21tYW5kIjpbImdvIiwidmVyc2lvbiJdLCJFbnRyeXBvaW50IjpudWxsLCJFbnYiOm51bGwsIkFzc2VydGlvbnMiOlsic3Rkb3V0LmluZGV4T2YoXCJnbzEuMTFcIikgIT0gLTEiXX0= | jq -r '.Stdout | @base64d'
 go version go1.16.4 linux/amd64
 ```
+
+### Integration tests
+There is an integration test for the build command in pkg/dazzle/build_test.go - TestProjectChunk_test_integration and a shell script to run it. 
+The integration test does an end-to-end check along with editing a test and re-running to ensure only the test image is updated.
+
+It requires a running Buildkitd instance at unix:///run/buildkit/buildkitd.sock and a docker registry on 127.0.0.1:5000 (i.e. as this workspace is setup on startup).
+
+Override the env vars BUILDKIT_ADDR and TARGET_REF as required prior to running in a different environment.
+
+```bash
+$ ./integration_tests.sh
+```

--- a/integration_tests.sh
+++ b/integration_tests.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# Run the integration tests
+# NOTE: the TARGET_REF is hostname:port 
+# shellcheck disable=SC2034
+BUILDKIT_ADDR=unix:///run/buildkit/buildkitd.sock; TARGET_REF=127.0.0.1:5000 go test -count 1 -run ^Test.*_integration$ github.com/csweichel/dazzle/pkg/dazzle -v

--- a/integration_tests.sh
+++ b/integration_tests.sh
@@ -3,4 +3,4 @@
 # Run the integration tests
 # NOTE: the TARGET_REF is hostname:port 
 # shellcheck disable=SC2034
-BUILDKIT_ADDR=unix:///run/buildkit/buildkitd.sock; TARGET_REF=127.0.0.1:5000 go test -count 1 -run ^Test.*_integration$ github.com/csweichel/dazzle/pkg/dazzle -v
+BUILDKIT_ADDR=unix:///run/buildkit/buildkitd.sock TARGET_REF=127.0.0.1:5000 go test -count 1 -run ^Test.*_integration$ github.com/csweichel/dazzle/pkg/dazzle -v

--- a/pkg/dazzle/build.go
+++ b/pkg/dazzle/build.go
@@ -556,11 +556,11 @@ func (p *ProjectChunk) test(ctx context.Context, sess *BuildSession) (ok bool, d
 
 	resultRef, err := p.ImageName(imageTypeTestResult, sess)
 	if err != nil {
-		return false, err
+		return false, false, err
 	}
 	r, err := pullTestResult(ctx, sess.opts.Registry, resultRef)
 	if err != nil && !errdefs.IsNotFound(err) {
-		return false, err
+		return false, false, err
 	}
 	if r != nil && r.Passed {
 		// tests have run before and have passed

--- a/pkg/dazzle/build_test.go
+++ b/pkg/dazzle/build_test.go
@@ -22,11 +22,22 @@ package dazzle
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"path/filepath"
 	"testing"
 	"testing/fstest"
+	"time"
 
 	"github.com/containerd/containerd/remotes"
+	"github.com/containerd/containerd/remotes/docker"
 	"github.com/docker/distribution/reference"
+
+	"github.com/moby/buildkit/client"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	ociv1 "github.com/opencontainers/image-spec/specs-go/v1"
 )
@@ -164,7 +175,7 @@ func TestProjectChunk_test(t *testing.T) {
 			if tt.fields.Registry != nil {
 				sess.opts.Registry = tt.fields.Registry
 			}
-			gotOk, err := chks[0].test(tt.args.ctx, tt.args.sess)
+			gotOk, _, err := chks[0].test(tt.args.ctx, tt.args.sess)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("ProjectChunk.test() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -206,3 +217,305 @@ func (t fakeResolver) Pusher(ctx context.Context, ref string) (remotes.Pusher, e
 	return nil, nil
 }
 
+type tagResponse struct {
+	Name string
+	Tags []string
+}
+
+func TestProjectChunk_test_integration(t *testing.T) {
+	// NOTE: requires a running Buildkit daemon and registry
+	buildkitAddr := os.Getenv("BUILDKIT_ADDR")
+	if buildkitAddr == "" {
+		t.Skip("set BUILDKIT_ADDR to run this test")
+	}
+	targetRef := os.Getenv("TARGET_REF")
+	if targetRef == "" {
+		t.Skip("set TARGET_REF to run this test")
+	}
+	// NOTE: using a ~unique target here to allow identification of the output from this test
+	targetRepo := fmt.Sprintf("integration_%d", time.Now().UnixNano())
+	fullTargetRef := fmt.Sprintf("%s/%s", targetRef, targetRepo)
+	ctx := context.Background()
+	cl, err := client.New(ctx, buildkitAddr, client.WithFailFast())
+	if err != nil {
+		t.Errorf("Could not create client: %v", err)
+		return
+	}
+	resolver := docker.NewResolver(docker.ResolverOptions{})
+	session, err := NewSession(cl, fullTargetRef,
+		WithResolver(resolver),
+		WithNoCache(true),
+		WithPlainOutput(true),
+		WithChunkedWithoutHash(false),
+	)
+	if err != nil {
+		t.Errorf("Could not create session: %v", err)
+		return
+	}
+
+	tmpDir := t.TempDir()
+	targetDir := tmpDir + "/testdata"
+	err = CopyDir("./testdata", targetDir)
+	if err != nil {
+		t.Errorf("TestProjectChunk_test_integration() could not copy testdata: %v", err)
+		return
+	}
+
+	prj, err := LoadFromDir(targetDir, LoadFromDirOpts{})
+	if err != nil {
+		t.Errorf("TestProjectChunk_test_integration() could not load project: %v", err)
+		return
+	}
+
+	// Ensure we don't have any existing tags in repository
+	httpClient := &http.Client{}
+	req, _ := http.NewRequest("GET", "http://"+targetRef+"/v2/"+targetRepo+"/tags/list", nil)
+	req.Header.Add("Accept", "application/json")
+
+	// Should not have any tags for this project
+	{
+		resp, err := httpClient.Do(req)
+		if err != nil {
+			t.Errorf("TestProjectChunk_test_integration() could not get tags from registry: %v", err)
+			return
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusNotFound {
+			t.Errorf("TestProjectChunk_test_integration() should not have tags: returned %v", resp)
+			return
+		}
+	}
+
+	err = prj.Build(context.Background(), session)
+	if err != nil {
+		t.Errorf("ProjectChunk.test() unexpected Build error = %v", err)
+		return
+	}
+
+	// Should now have tags for this project
+	{
+		resp, err := httpClient.Do(req)
+		if err != nil {
+			t.Errorf("TestProjectChunk_test_integration() could not get tags from registry: %v", err)
+			return
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Errorf("TestProjectChunk_test_integration() should have tags: returned %v", resp)
+			return
+		}
+
+		var tagResp tagResponse
+		// Decode the data
+		if err := json.NewDecoder(resp.Body).Decode(&tagResp); err != nil {
+			t.Errorf("TestProjectChunk_test_integration() could not get decode tags from registry: %v", err)
+			return
+		}
+		if len(tagResp.Tags) != 5 {
+			t.Errorf("TestProjectChunk_test_integration() expected 5 tags from registry: got %v", tagResp.Tags)
+			return
+		}
+	}
+
+	// Re-running build should reuse existing images & tags
+	err = prj.Build(context.Background(), session)
+	if err != nil {
+		t.Errorf("ProjectChunk.test() unexpected rebuild 1 error = %v", err)
+		return
+	}
+
+	// Should not have any new tags for this project
+	{
+		resp, err := httpClient.Do(req)
+		if err != nil {
+			t.Errorf("TestProjectChunk_test_integration() could not get tags from registry: %v", err)
+			return
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Errorf("TestProjectChunk_test_integration() should have tags: returned %v", resp)
+			return
+		}
+
+		var tagResp tagResponse
+		// Decode the data
+		if err := json.NewDecoder(resp.Body).Decode(&tagResp); err != nil {
+			t.Errorf("TestProjectChunk_test_integration() could not get decode tags from registry: %v", err)
+			return
+		}
+		if len(tagResp.Tags) != 5 {
+			t.Errorf("TestProjectChunk_test_integration() expected 5 tags from registry: got %v", tagResp.Tags)
+			return
+		}
+	}
+
+	// Individually check each chunk to ensure it doesn't rebuild
+	for _, chk := range prj.Chunks {
+		ok, didRun, err := chk.test(ctx, session)
+		if err != nil || !ok || didRun {
+			t.Errorf("TestProjectChunk_test_integration() error:%v testing chunk: %s with results: %v:%v", err, chk.Name, ok, didRun)
+			return
+		}
+
+		_, didBuild, err := chk.build(ctx, session)
+		if err != nil || didBuild {
+			t.Errorf("TestProjectChunk_test_integration() error:%v building chunk: %s didBuild:%v", err, chk.Name, didBuild)
+			return
+		}
+	}
+
+	// Modify a test and ensure it is rebuilt
+	newTest := []byte(`- desc: "it should have xxx"
+  command: ["sh", "-c", "ls -tl xxx"]
+  assert:
+    - "status == 0"
+    - stdout.indexOf("xxx") != -1`)
+
+	err = ioutil.WriteFile(targetDir+"/tests/basic.yaml", newTest, 0644)
+	if err != nil {
+		t.Errorf("TestProjectChunk_test_integration() error:%v writing new test", err)
+		return
+	}
+
+	// Reload to get new test
+	prj, err = LoadFromDir(targetDir, LoadFromDirOpts{})
+	if err != nil {
+		t.Errorf("TestProjectChunk_test_integration() could not reload project: %v", err)
+		return
+	}
+
+	// Re-running build should create a new test tags
+	err = prj.Build(context.Background(), session)
+	if err != nil {
+		t.Errorf("ProjectChunk.test() unexpected rebuild 2 error = %v", err)
+		return
+	}
+
+	// Should now have new test tags for this project
+	{
+		resp, err := httpClient.Do(req)
+		if err != nil {
+			t.Errorf("TestProjectChunk_test_integration() could not get tags from registry: %v", err)
+			return
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Errorf("TestProjectChunk_test_integration() should have tags: returned %v", resp)
+			return
+		}
+
+		var tagResp tagResponse
+		// Decode the data
+		if err := json.NewDecoder(resp.Body).Decode(&tagResp); err != nil {
+			t.Errorf("TestProjectChunk_test_integration() could not get decode tags from registry: %v", err)
+			return
+		}
+		if len(tagResp.Tags) != 7 {
+			t.Errorf("TestProjectChunk_test_integration() expected 7 tags from registry: got %v", tagResp.Tags)
+			return
+		}
+	}
+}
+
+// FROM: https://gist.github.com/r0l1/92462b38df26839a3ca324697c8cba04
+// CopyFile copies the contents of the file named src to the file named
+// by dst. The file will be created if it does not already exist. If the
+// destination file exists, all it's contents will be replaced by the contents
+// of the source file. The file mode will be copied from the source and
+// the copied data is synced/flushed to stable storage.
+func CopyFile(src, dst string) (err error) {
+	in, err := os.Open(src)
+	if err != nil {
+		return
+	}
+	defer in.Close()
+
+	out, err := os.Create(dst)
+	if err != nil {
+		return
+	}
+	defer func() {
+		if e := out.Close(); e != nil {
+			err = e
+		}
+	}()
+
+	_, err = io.Copy(out, in)
+	if err != nil {
+		return
+	}
+
+	err = out.Sync()
+	if err != nil {
+		return
+	}
+
+	si, err := os.Stat(src)
+	if err != nil {
+		return
+	}
+	err = os.Chmod(dst, si.Mode())
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// CopyDir recursively copies a directory tree, attempting to preserve permissions.
+// Source directory must exist, destination directory must *not* exist.
+// Symlinks are ignored and skipped.
+func CopyDir(src string, dst string) (err error) {
+	src = filepath.Clean(src)
+	dst = filepath.Clean(dst)
+
+	si, err := os.Stat(src)
+	if err != nil {
+		return err
+	}
+	if !si.IsDir() {
+		return fmt.Errorf("source is not a directory")
+	}
+
+	_, err = os.Stat(dst)
+	if err != nil && !os.IsNotExist(err) {
+		return
+	}
+	if err == nil {
+		return fmt.Errorf("destination already exists")
+	}
+
+	err = os.MkdirAll(dst, si.Mode())
+	if err != nil {
+		return
+	}
+
+	entries, err := ioutil.ReadDir(src)
+	if err != nil {
+		return
+	}
+
+	for _, entry := range entries {
+		srcPath := filepath.Join(src, entry.Name())
+		dstPath := filepath.Join(dst, entry.Name())
+
+		if entry.IsDir() {
+			err = CopyDir(srcPath, dstPath)
+			if err != nil {
+				return
+			}
+		} else {
+			// Skip symlinks.
+			if entry.Mode()&os.ModeSymlink != 0 {
+				continue
+			}
+
+			err = CopyFile(srcPath, dstPath)
+			if err != nil {
+				return
+			}
+		}
+	}
+
+	return
+}

--- a/pkg/dazzle/build_test.go
+++ b/pkg/dazzle/build_test.go
@@ -37,7 +37,7 @@ func TestProjectChunk_test(t *testing.T) {
 	if err != nil {
 		t.Errorf("could not create session:%v", err)
 	}
-	sess.opts.Resolver = testResolver{}
+	sess.opts.Resolver = fakeResolver{}
 
 	type fields struct {
 		Name     string
@@ -123,7 +123,7 @@ func TestProjectChunk_test(t *testing.T) {
 `),
 					},
 				},
-				Registry: testRegistry{
+				Registry: fakeRegistry{
 					testResult: &StoredTestResult{
 						Passed: true,
 					},
@@ -176,15 +176,15 @@ func TestProjectChunk_test(t *testing.T) {
 	}
 }
 
-type testRegistry struct {
+type fakeRegistry struct {
 	testResult *StoredTestResult
 }
 
-func (t testRegistry) Push(ctx context.Context, ref reference.Named, opts storeInRegistryOptions) (absref reference.Digested, err error) {
+func (t fakeRegistry) Push(ctx context.Context, ref reference.Named, opts storeInRegistryOptions) (absref reference.Digested, err error) {
 	return nil, nil
 }
 
-func (t testRegistry) Pull(ctx context.Context, ref reference.Reference, cfg interface{}) (manifest *ociv1.Manifest, absref reference.Digested, err error) {
+func (t fakeRegistry) Pull(ctx context.Context, ref reference.Reference, cfg interface{}) (manifest *ociv1.Manifest, absref reference.Digested, err error) {
 	if t.testResult != nil {
 		r := cfg.(*StoredTestResult)
 		r.Passed = t.testResult.Passed
@@ -192,16 +192,17 @@ func (t testRegistry) Pull(ctx context.Context, ref reference.Reference, cfg int
 	return nil, nil, nil
 }
 
-type testResolver struct{}
+type fakeResolver struct{}
 
-func (t testResolver) Resolve(ctx context.Context, ref string) (name string, desc ocispec.Descriptor, err error) {
+func (t fakeResolver) Resolve(ctx context.Context, ref string) (name string, desc ocispec.Descriptor, err error) {
 	return "test", ocispec.Descriptor{}, nil
 }
 
-func (t testResolver) Fetcher(ctx context.Context, ref string) (remotes.Fetcher, error) {
+func (t fakeResolver) Fetcher(ctx context.Context, ref string) (remotes.Fetcher, error) {
 	return nil, nil
 }
 
-func (t testResolver) Pusher(ctx context.Context, ref string) (remotes.Pusher, error) {
+func (t fakeResolver) Pusher(ctx context.Context, ref string) (remotes.Pusher, error) {
 	return nil, nil
 }
+

--- a/pkg/dazzle/testdata/base/Dockerfile
+++ b/pkg/dazzle/testdata/base/Dockerfile
@@ -1,0 +1,1 @@
+FROM registry:2

--- a/pkg/dazzle/testdata/chunks/basic/Dockerfile
+++ b/pkg/dazzle/testdata/chunks/basic/Dockerfile
@@ -1,0 +1,4 @@
+ARG base
+FROM ${base}
+
+RUN touch xxx

--- a/pkg/dazzle/testdata/dazzle.yaml
+++ b/pkg/dazzle/testdata/dazzle.yaml
@@ -1,0 +1,8 @@
+combiner:
+  combinations:
+    - name: all
+      chunks:
+        - basic
+  envvars:
+    - name: PATH
+      action: merge-unique

--- a/pkg/dazzle/testdata/tests/basic.yaml
+++ b/pkg/dazzle/testdata/tests/basic.yaml
@@ -1,0 +1,5 @@
+- desc: "it should have xxx"
+  command: ["sh", "-c", "ls xxx"]
+  assert:
+    - "status == 0"
+    - stdout.indexOf("xxx") != -1

--- a/pkg/test/runner/build.sh
+++ b/pkg/test/runner/build.sh
@@ -5,8 +5,17 @@ GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o bin/runner_linux_amd64 main.go
 curl -L https://github.com/upx/upx/releases/download/v3.96/upx-3.96-amd64_linux.tar.xz | tar xJ
 upx-3.96-amd64_linux/upx bin/runner_linux_amd64 
 rm -r upx-3.96-amd64_linux
-go get github.com/GeertJohan/go.rice/rice
-rice embed-go -i github.com/csweichel/dazzle/pkg/test/runner
+go install github.com/GeertJohan/go.rice/rice@v1.0.2
+RICEBIN="$GOBIN"
+if [ -z "$RICEBIN" ]; then
+  if [ -z "$GOPATH" ]; then
+    RICEBIN="$HOME"/go/bin
+  else
+    RICEBIN="$GOPATH"/bin
+  fi
+fi
+
+"$RICEBIN"/rice embed-go -i github.com/csweichel/dazzle/pkg/test/runner
 
 if [ $(ls -l bin/runner_linux_amd64 | cut -d ' ' -f 5) -gt 3437900 ]; then
     echo "runner binary is too big (> gRPC message size)"


### PR DESCRIPTION
I did go down the [rabbit hole ](https://github.com/gitpod-io/dazzle/commits/rl/test-with-in-proc-reg)of attempting to unit test this but it is, by necessity, pretty tightly coupled to the Buildkit & docker registry backends and it became increasingly fragile to keep going down that path so I backed up and went for an integration test that does a reasonable job of covering the build phase basics - definitely more to be done there.

Can we chat about how best to get this running in CI at some point?