### PR TITLE
Add Combine configuration & more logging for Combine testing

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -19,6 +19,23 @@
             ]
         },
         {
+            "name": "Dazzle example combine",
+            "type": "go",
+            "request": "launch",
+            "mode": "auto",
+            "program": "${fileWorkspaceFolder}",
+            "args": [
+                "combine",
+                "--addr",
+                "unix:///run/buildkit/buildkitd.sock",
+                "--context",
+                "example",
+                "localhost:5000/dazzle",
+                "--all",
+                "."
+            ]
+        },
+        {
             "name": "Dazzle runner",
             "type": "go",
             "request": "launch",

--- a/example.sh
+++ b/example.sh
@@ -3,3 +3,4 @@
 # Build and run the example
 gp await-port 5000
 go run main.go build --context example localhost:5000/dazzle
+go run main.go combine --context example localhost:5000/dazzle --all

--- a/example/base/Dockerfile
+++ b/example/base/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.10
+FROM ubuntu:20.04
 
 COPY readme.md /
 RUN  apt-get update && apt-get install -y curl tar bash && rm -rf /var/lib/apt/lists/*

--- a/pkg/dazzle/build.go
+++ b/pkg/dazzle/build.go
@@ -170,7 +170,7 @@ func (p *Project) Build(ctx context.Context, session *BuildSession) error {
 	for _, chk := range p.Chunks {
 		_, _, err := chk.test(ctx, session)
 		if err != nil {
-			return fmt.Errorf("cannot build chunk %s: %w", chk.Name, err)
+			return fmt.Errorf("cannot test chunk %s: %w", chk.Name, err)
 		}
 
 		_, _, err = chk.build(ctx, session)


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
1. On Combine, when merging environment variables, log the value we're trying to merge, so we can compare it with the product
2. Change example base image to Ubuntu 20.04 LTS (20.10 fails)
3. Add Combine to VSCode debug configuration and example.sh

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
n/a

## How to test
<!-- Provide steps to test this PR -->
Start this in Gitpod
Run the Build configuration
Run the Combine configuration

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Improve Combine logging when merging env vars
```
