### PR TITLE
Ensure that `EnvVarCombineMergeUnique` keeps order

### DIFF
--- a/pkg/dazzle/combiner.go
+++ b/pkg/dazzle/combiner.go
@@ -319,12 +319,18 @@ func mergeEnv(base *ociv1.Image, others []*ociv1.Image, vars []EnvVarCombination
 						vss []string
 						idx = make(map[string]struct{})
 					)
-					for _, v := range vs {
+					lenVS := len(vs) - 1
+					for i := range vs {
+						v := vs[lenVS-i]
 						if _, exists := idx[v]; exists {
 							continue
 						}
 						idx[v] = struct{}{}
 						vss = append(vss, v)
+					}
+
+					for i, j := 0, len(vss)-1; i < j; i, j = i+1, j-1 {
+						vss[i], vss[j] = vss[j], vss[i]
 					}
 					envs[k] = strings.Join(vss, ":")
 				}

--- a/pkg/dazzle/combiner.go
+++ b/pkg/dazzle/combiner.go
@@ -315,17 +315,16 @@ func mergeEnv(base *ociv1.Image, others []*ociv1.Image, vars []EnvVarCombination
 					vs = append(vs, strings.Split(envValue, ":")...)
 					vs = append(vs, strings.Split(v, ":")...)
 
-					vss := []string{}
-					flags := make(map[string]bool)
-					for i := len(vs) - 1; i >= 0; i-- {
-						entry := vs[i]
-						if _, value := flags[entry]; !value {
-							flags[entry] = true
-							vss = append(vss, entry)
+					var (
+						vss []string
+						idx = make(map[string]struct{})
+					)
+					for _, v := range vs {
+						if _, exists := idx[v]; exists {
+							continue
 						}
-					}
-					for i, j := 0, len(vss)-1; i < j; i, j = i+1, j-1 {
-						vss[i], vss[j] = vss[j], vss[i]
+						idx[v] = struct{}{}
+						vss = append(vss, v)
 					}
 					envs[k] = strings.Join(vss, ":")
 				}

--- a/pkg/dazzle/combiner.go
+++ b/pkg/dazzle/combiner.go
@@ -311,14 +311,25 @@ func mergeEnv(base *ociv1.Image, others []*ociv1.Image, vars []EnvVarCombination
 				case EnvVarCombineMerge:
 					envs[k] += ":" + v
 				case EnvVarCombineMergeUnique:
-					vs := make(map[string]struct{})
+					var vs []string
 					for _, s := range strings.Split(envValue, ":") {
-						vs[s] = struct{}{}
+						vs = append(vs, s)
 					}
-					vs[v] = struct{}{}
-					vss := make([]string, 0, len(vs))
-					for s := range vs {
-						vss = append(vss, s)
+					for _, s := range strings.Split(v, ":") {
+						vs = append(vs, s)
+					}
+
+					vss := []string{}
+					flags := make(map[string]bool)
+					for i := len(vs) - 1; i >= 0; i-- {
+						entry := vs[i]
+						if _, value := flags[entry]; !value {
+							flags[entry] = true
+							vss = append(vss, entry)
+						}
+					}
+					for i, j := 0, len(vss)-1; i < j; i, j = i+1, j-1 {
+						vss[i], vss[j] = vss[j], vss[i]
 					}
 					envs[k] = strings.Join(vss, ":")
 				}

--- a/pkg/dazzle/combiner.go
+++ b/pkg/dazzle/combiner.go
@@ -312,12 +312,8 @@ func mergeEnv(base *ociv1.Image, others []*ociv1.Image, vars []EnvVarCombination
 					envs[k] += ":" + v
 				case EnvVarCombineMergeUnique:
 					var vs []string
-					for _, s := range strings.Split(envValue, ":") {
-						vs = append(vs, s)
-					}
-					for _, s := range strings.Split(v, ":") {
-						vs = append(vs, s)
-					}
+					vs = append(vs, strings.Split(envValue, ":")...)
+					vs = append(vs, strings.Split(v, ":")...)
 
 					vss := []string{}
 					flags := make(map[string]bool)

--- a/pkg/dazzle/combiner_test.go
+++ b/pkg/dazzle/combiner_test.go
@@ -62,7 +62,7 @@ func TestMergeEnv(t *testing.T) {
 				{
 					Config: ociv1.ImageConfig{
 						Env: []string{
-							"PATH=seventh:eighth:seventh:common-value",
+							"PATH=eighth:seventh:eighth:common-value",
 						},
 					},
 				},
@@ -73,7 +73,7 @@ func TestMergeEnv(t *testing.T) {
 					Action: EnvVarCombineMergeUnique,
 				},
 			},
-			expect: []string{"PATH=first:second:third:common-value:fourth:fifth:sixth:seventh:eighth"},
+			expect: []string{"PATH=first:second:third:fourth:fifth:sixth:seventh:eighth:common-value"},
 		},
 		{
 			name: "EnvVarCombineMerge",

--- a/pkg/dazzle/combiner_test.go
+++ b/pkg/dazzle/combiner_test.go
@@ -1,0 +1,80 @@
+// Copyright © 2020 Gitpod
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package dazzle
+
+import (
+	"testing"
+
+	ociv1 "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+func TestMergeEnv(t *testing.T) {
+	base := ociv1.Image{
+		Config: ociv1.ImageConfig{
+			Env: []string{
+				"PATH=first:second:third:$PATH",
+			},
+		},
+	}
+	others := []*ociv1.Image{
+		{
+			Config: ociv1.ImageConfig{
+				Env: []string{
+					"PATH=fourth:fifth:$PATH",
+				},
+			},
+		},
+		{
+			Config: ociv1.ImageConfig{
+				Env: []string{
+					"PATH=sixth:sixth:$PATH",
+				},
+			},
+		},
+		{
+			Config: ociv1.ImageConfig{
+				Env: []string{
+					"PATH=eighth:seventh:eighth:$PATH",
+				},
+			},
+		},
+	}
+	vars := []EnvVarCombination{
+		{
+			Name:   "PATH",
+			Action: EnvVarCombineMergeUnique,
+		},
+	}
+	envs, err := mergeEnv(&base, others, vars)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expect := []string{"PATH=first:second:third:fourth:fifth:sixth:seventh:eighth:$PATH"}
+	if len(envs) != len(expect) {
+		t.Fatal("unexpected length", len(envs))
+	}
+	for i, env := range envs {
+		if env != expect[i] {
+			t.Fatal("unexpected env", envs)
+		}
+
+	}
+}

--- a/pkg/dazzle/combiner_test.go
+++ b/pkg/dazzle/combiner_test.go
@@ -27,8 +27,6 @@ import (
 )
 
 func TestMergeEnv(t *testing.T) {
-	type args struct {
-	}
 	tests := []struct {
 		name   string
 		base   *ociv1.Image


### PR DESCRIPTION
## Description

This pr resolves an issue where the order of env vars would be random when merging them
If there are the same env var, the latter will be given priority.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #42

## How to test
There are two ways to confirm the behavior
### Unit test
```console
$ go test -v ./...
```

### Create an actual image

Create the following files to create the image.

`base/Dockerfile`
```Dockerfile
FROM ubuntu:latest
```
`chunks/golang/Dockerfile`
```Dockerfile
ARG base
FROM ${base}

RUN mkdir -p /root/go/bin
ENV PATH=/root/go/bin:$PATH
```
`chunks/pyenv/Dockerfile`
```Dockerfile
ARG base
FROM ${base}

RUN mkdir -p /root/.pyenv/bin /root/.pyenv/shims
ENV PATH=/root/.pyenv/bin:/root/.pyenv/shims:$PATH
```
`dazzle.yaml`
```yaml
combiner:
  combinations:
  - name: full
    ref: []
    chunks:
    - pyenv
    - golang
  envvars:
    - name: PATH
      action: merge-unique
```

Re-create the image several times to make sure the PATH remains constant.
```console
$ docker run --rm localhost:5000/test:full env | grep PATH
PATH=/root/.pyenv/bin:/root/.pyenv/shims:/root/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Ensure that EnvVarCombineMergeUnique keeps order
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
