### PR TITLE
Support for zstd compression layer

### DIFF
--- a/cmd/core/build.go
+++ b/cmd/core/build.go
@@ -22,6 +22,7 @@ package core
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/moby/buildkit/client"
 	"github.com/spf13/cobra"
@@ -60,7 +61,21 @@ var buildCmd = &cobra.Command{
 			return err
 		}
 
-		err = prj.Build(context.Background(), session)
+		var compression dazzle.Compression
+		c, err := cmd.Flags().GetString("compression")
+		if err != nil {
+			return err
+		}
+		switch c {
+		case "gzip":
+			compression = dazzle.Gzip
+		case "zstd":
+			compression = dazzle.Zstd
+		default:
+			return fmt.Errorf("unknow a compression type: %s", c)
+		}
+
+		err = prj.Build(context.Background(), session, compression)
 		if err != nil {
 			return err
 		}
@@ -77,4 +92,5 @@ func init() {
 	buildCmd.Flags().Bool("no-cache", false, "disables the buildkit build cache")
 	buildCmd.Flags().Bool("plain-output", false, "produce plain output")
 	buildCmd.Flags().Bool("chunked-without-hash", false, "disable hash qualification for chunked image")
+	buildCmd.Flags().String("compression", "gzip", "compression type for layers")
 }

--- a/cmd/core/combine.go
+++ b/cmd/core/combine.go
@@ -85,6 +85,20 @@ var combineCmd = &cobra.Command{
 			bldref = targetref.String()
 		}
 
+		var compression dazzle.Compression
+		c, err := cmd.Flags().GetString("compression")
+		if err != nil {
+			return err
+		}
+		switch c {
+		case "gzip":
+			compression = dazzle.Gzip
+		case "zstd":
+			compression = dazzle.Zstd
+		default:
+			return fmt.Errorf("unknow a compression type: %s", c)
+		}
+
 		cl, err := client.New(context.Background(), rootCfg.BuildkitAddr, client.WithFailFast())
 		if err != nil {
 			return err
@@ -112,7 +126,7 @@ var combineCmd = &cobra.Command{
 			}
 
 			log.WithField("combination", cmb.Name).WithField("chunks", cmb.Chunks).WithField("ref", destref.String()).Warn("producing chunk combination")
-			err = prj.Combine(context.Background(), cmb.Chunks, destref, sess, opts...)
+			err = prj.Combine(context.Background(), cmb.Chunks, destref, sess, compression, opts...)
 			if err != nil {
 				return err
 			}
@@ -130,4 +144,5 @@ func init() {
 	combineCmd.Flags().String("combination", "", "build a specific combination")
 	combineCmd.Flags().Bool("all", false, "build all combinations")
 	combineCmd.Flags().String("build-ref", "", "use a different build-ref than the target-ref")
+	combineCmd.Flags().String("compression", "gzip", "compression type for layers")
 }

--- a/example.sh
+++ b/example.sh
@@ -2,5 +2,5 @@
 
 # Build and run the example
 gp await-port 5000
-go run main.go build --context example localhost:5000/dazzle
-go run main.go combine --context example localhost:5000/dazzle --all
+go run main.go build --context example localhost:5000/dazzle --compression gzip
+go run main.go combine --context example localhost:5000/dazzle --all --compression gzip

--- a/pkg/dazzle/combiner.go
+++ b/pkg/dazzle/combiner.go
@@ -62,7 +62,7 @@ func asTempBuild(o *combinerOpts) error {
 
 // Combine combines a set of previously built chunks into a single image while maintaining
 // the layer identity.
-func (p *Project) Combine(ctx context.Context, chunks []string, dest reference.Named, sess *BuildSession, opts ...CombinerOpt) (err error) {
+func (p *Project) Combine(ctx context.Context, chunks []string, dest reference.Named, sess *BuildSession, compression Compression, opts ...CombinerOpt) (err error) {
 	var options combinerOpts
 	for _, o := range opts {
 		err = o(&options)
@@ -78,7 +78,7 @@ func (p *Project) Combine(ctx context.Context, chunks []string, dest reference.N
 		if err != nil {
 			return err
 		}
-		err = p.Combine(ctx, chunks, tmpdest, sess, append(opts, asTempBuild)...)
+		err = p.Combine(ctx, chunks, tmpdest, sess, compression, append(opts, asTempBuild)...)
 		if err != nil {
 			return err
 		}

--- a/pkg/dazzle/compression.go
+++ b/pkg/dazzle/compression.go
@@ -1,0 +1,50 @@
+// Copyright © 2022 Gitpod
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package dazzle
+
+import ociv1 "github.com/opencontainers/image-spec/specs-go/v1"
+
+type Compression int
+
+const (
+	Gzip Compression = iota
+	Zstd
+)
+
+func (compression *Compression) Extension() string {
+	switch *compression {
+	case Gzip:
+		return ociv1.MediaTypeImageLayerGzip
+	case Zstd:
+		return ociv1.MediaTypeImageLayerZstd
+	}
+	return ociv1.MediaTypeImageLayerGzip
+}
+
+func (compression *Compression) String() string {
+	switch *compression {
+	case Gzip:
+		return "gzip"
+	case Zstd:
+		return "zstd"
+	}
+	return "gzip"
+}

--- a/pkg/dazzle/project_test.go
+++ b/pkg/dazzle/project_test.go
@@ -1,4 +1,4 @@
-// Copyright © 2020 Gitpod
+// Copyright © 2022 Gitpod
 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Support for zstd[^1][^2][^3] compression.
zstd is said to be much faster than gzip. However, I believe zstd is still in the experimental stage.
https://github.com/opencontainers/image-spec/issues/803

Moby has completed the corresponding [implementation](https://github.com/moby/moby/pull/41759) but it has not yet been released. buildkit has completed its support, as you can see from its implementation. `nerdctl` can be used to confirm that it works.

[^1]: https://www.infoq.com/news/2022/09/amazon-gzip-zstd/
[^2]: https://aws.amazon.com/blogs/containers/reducing-aws-fargate-startup-times-with-zstd-compressed-container-images/
[^3]: https://www.slideshare.net/KoheiTokunaga/starting-up-containers-super-fast-with-lazy-pulling-of-images

```json
{
  "schemaVersion": 2,
  "config": {
    "mediaType": "application/vnd.oci.image.config.v1+json",
    "digest": "sha256:a2723dd59ae9025fd33b77ae7316a77406fcd08d0077bcf5819fec5e5e49f6e6",
    "size": 3930
  },
  "layers": [
    {
      "mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
      "digest": "sha256:fb0b3276a519f5e7085f51c75989b287b234b3508e1524cf2cdcbc397c06ec3d",
      "size": 28574451
    },
    {
      "mediaType": "application/vnd.oci.image.layer.v1.tar+zstd",
      "digest": "sha256:f3bdd52e8a0a2c581486e84c029b6e45571656416d62d9f11561714a7e202ec1",
      "size": 139
    },
    {
      "mediaType": "application/vnd.oci.image.layer.v1.tar+zstd",
      "digest": "sha256:21930dd1a8bd2c1d054c0c737ff3ff21fa0ae99fc830ab44df1136c72f94352b",
      "size": 6542185
    },
    {
      "mediaType": "application/vnd.oci.image.layer.v1.tar+zstd",
      "digest": "sha256:6cf4a0e124673f39bd1ea8c7ff37f22e929e3db4217a5bf5e5d165a8efc88573",
      "size": 123049956
    },
    {
      "mediaType": "application/vnd.oci.image.layer.v1.tar+zstd",
      "digest": "sha256:693583e208bc9a66aaf4096d4488d38768fcf4445602de8cda06e4dbcdc4c6e7",
      "size": 65642862
    },
    {
      "mediaType": "application/vnd.oci.image.layer.v1.tar+zstd",
      "digest": "sha256:92d8ef9231fc6aa6a7b4776809c54257a2aa4924e11a276a8f00fd876dcadedc",
      "size": 33833622
    },
    {
      "mediaType": "application/vnd.oci.image.layer.v1.tar+zstd",
      "digest": "sha256:e0ba2d4918a6886a1e4afd68840266200e7a5bc4433bce1d6029e1f8b1f1cebf",
      "size": 774
    },
    {
      "mediaType": "application/vnd.oci.image.layer.v1.tar+zstd",
      "digest": "sha256:4d37bcae4df9957c8e7fc3dcbb8b1d0d206515b9fd088e4dd7e22ee02b9cc01a",
      "size": 336616
    }
  ],
  "annotations": {
    "dazzle.gitpod.io/base-ref": "localhost:5000/dazzle:base--bd2b6e028018842142b5de640d18f91d9ac8cb22eae851087e116b678ac95f36@sha256:0d19fc62337e316b122853b1a319d500fcc5857f1fe3f4b56ff14d47971e6881"
  }
}
```

## Related Issue(s)
<!-- List the issue(s) this PR solves -->

https://github.com/gitpod-io/workspace-images/pull/951#issuecomment-1278297068

## How to test
<!-- Provide steps to test this PR -->

```console
$ gp await-port 5000
$ go run main.go build --context example localhost:5000/dazzle --compression zstd
$ go run main.go combine --context example localhost:5000/dazzle --all --compression zstd
$ go install github.com/csweichel/oci-tool@latest
$ oci-tool fetch raw localhost:5000/dazzle:all | jq # you can see `tar+zstd`
```

You can confirm that nerdctl works from your terminal by opening port 5000.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
dazzle: Support for zstd compression
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
