### PR TITLE
Prevent creation of windows binaries

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -7,6 +7,9 @@ builds:
   - CGO_ENABLED=0
   ldflags:
   - -s -w -X github.com/gitpod-io/dazzle/cmd/core.version={{.Version}}-{{.ShortCommit}}
+  goos:
+  - darwin
+  - linux
 - id: dazzle-util
   env:
   - CGO_ENABLED=0
@@ -16,6 +19,9 @@ builds:
     - -tags=util
   ldflags:
   - -s -w -X github.com/gitpod-io/dazzle/cmd/util.version={{.Version}}-{{.ShortCommit}}
+  goos:
+  - darwin
+  - linux
 archives:
 - id: dazzle
   replacements:


### PR DESCRIPTION
## Description
Starting with Go 1.17 goreleaser is building windows binaries by default. See https://github.com/gitpod-io/dazzle/actions/runs/3802356242. 

## Related Issue(s)
n.a.

## How to test
- Open workspace and execute  `goreleaser release --snapshot --rm-dist`. 

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```
